### PR TITLE
make THEN step for visibility ignore irrelevant invisible elements

### DIFF
--- a/addon-test-support/-private/steps/power-select.js
+++ b/addon-test-support/-private/steps/power-select.js
@@ -24,9 +24,10 @@ const steps = {
     const trigger = powerSelectFindTrigger(element);
     assert('Trigger not found', trigger);
 
+    const hasAriaDisabled = trigger.getAttribute('aria-disabled');
     not
-      ? expect(trigger).not.to.have.attr('aria-disabled')
-      : expect(trigger).to.have.attr('aria-disabled');
+      ? expect(hasAriaDisabled).not.be.oneOf([null, false])
+      : expect(hasAriaDisabled).to.be.truthy;
   },
 
   async "Then there should be (NO|no )?(?:(\\d+) )items? in the dropdown $opinionatedElement"(no, countStr, [collection/* , label, selector */]) {

--- a/addon-test-support/-private/steps/then.js
+++ b/addon-test-support/-private/steps/then.js
@@ -64,20 +64,21 @@ const steps = {
   },
 
   "Then (?:(\\d+) )?$opinionatedElement should (not |NOT )?be visible"(countRaw, [collection/* , label, selector */], no) {
-    assert(`Don't use NOT and number at the same time`, !(no && countRaw));
-
-    let count =
-      no       ? 0                      :
+    const count =
       countRaw ? parseInt(countRaw, 10) :
                  1;
-
-    let m = `Element count`;
-    expect(collection, m).to.have.length(count);
-
-    collection.forEach((element, i) => {
-      m = `Element #${i} (zero-indexed) visibility`;
-      expect(isVisible(element), m).to.be.true;
-    });
+    const countVisible = collection.filter(element => isVisible(element)).length;
+    if (no) {
+      if (countRaw !== undefined) {
+        // check exact match of invisible elements
+        expect(collection.length - countVisible, 'Invisible element count').to.equal(count);
+      } else {
+        // check no element is visible
+        expect(countVisible, 'Visible element count').to.equal(0);
+      }
+    } else {
+      expect(countVisible, 'Visible element count').to.equal(count);
+    }
   },
 
   "Then I should see (NO |no )?(?:(\\d+) )?$opinionatedElement"(no, countRaw, [collection, label, selector]) {

--- a/addon-test-support/-private/steps/then.js
+++ b/addon-test-support/-private/steps/then.js
@@ -64,20 +64,18 @@ const steps = {
   },
 
   "Then (?:(\\d+) )?$opinionatedElement should (not |NOT )?be visible"(countRaw, [collection/* , label, selector */], no) {
-    assert(`Don't use NOT and number at the same time`, !(no && countRaw));
-
     let count =
-      no       ? 0                      :
       countRaw ? parseInt(countRaw, 10) :
                  1;
 
-    let m = `Element count`;
-    expect(collection, m).to.have.length(count);
-
-    collection.forEach((element, i) => {
-      m = `Element #${i} (zero-indexed) visibility`;
-      expect(isVisible(element), m).to.be.true;
-    });
+    const countVisible = collection.filter(element => isVisible(element)).length;
+    if (no) {
+      let m = `Invisible element count`;
+      expect(collection.length - countVisible, m).to.equal(count);
+    } else {
+      let m = `Visible element count`;
+      expect(countVisible, m).to.equal(count);
+    }
   },
 
   "Then I should see (NO |no )?(?:(\\d+) )?$opinionatedElement"(no, countRaw, [collection, label, selector]) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-yadda-opinionated",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "description": "A radical take on Cucumber to solve your test maintenance woes.",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
**Short:**
when checking that `COUNT` elements are in/visible do not check the count of all found element but rather the count of those that are visible or invisible. This also allows to combine providing the `COUNT` with using the `NOT` option, e.g. `Then 10 elements should not be visible`.

**Long:**
I came across a scenario where one of multiple elements would be visible, e.g.
```hbs
<BsCollapse @collapsed={{true}}>
  <div data-test-my-element>
    abc123
  </div>
</BsCollapse>
<BsCollapse @collapsed={{false}}>
  <div data-test-my-element>
    abc123
  </div>
</BsCollapse>
```

the following steps would fail:
```
Then I should see 1 MyElement
Then 1 MyElement should be visible
```

They would fail due to the check of collection count before getting to the check for actual visibility
```typescript
"Then (?:(\\d+) )?$opinionatedElement should (not |NOT )?be visible"(countRaw, [collection/* , label, selector */], no) {
    assert(`Don't use NOT and number at the same time`, !(no && countRaw));

    let count =
      no       ? 0                      :
      countRaw ? parseInt(countRaw, 10) :
                 1;

    let m = `Element count`;
    expect(collection, m).to.have.length(count);

    collection.forEach((element, i) => {
      m = `Element #${i} (zero-indexed) visibility`;
      expect(isVisible(element), m).to.be.true;
    });
  }
```

So I suppose one can ignore the actual collection length but rather check the count based on each element's visibility.